### PR TITLE
Fix deprecation warning in PHP 8.4

### DIFF
--- a/src/MinCoverage/MinCoverageResult.php
+++ b/src/MinCoverage/MinCoverageResult.php
@@ -61,7 +61,7 @@ class MinCoverageResult
     public static function mapFromRulesAndMetrics(
         MinCoverageRules $minCoverageRules,
         array $metrics,
-        CoverageMetric|null $metricTotal = null,
+        ?CoverageMetric $metricTotal = null,
     ): array {
         $results = [];
         foreach ($minCoverageRules->getRules() as $minCoverageRule) {

--- a/src/MinCoverage/MinCoverageResult.php
+++ b/src/MinCoverage/MinCoverageResult.php
@@ -61,7 +61,7 @@ class MinCoverageResult
     public static function mapFromRulesAndMetrics(
         MinCoverageRules $minCoverageRules,
         array $metrics,
-        CoverageMetric $metricTotal = null,
+        CoverageMetric|null $metricTotal = null,
     ): array {
         $results = [];
         foreach ($minCoverageRules->getRules() as $minCoverageRule) {


### PR DESCRIPTION
This fixes deprecation warning in PHP 8.4
```
Deprecated: RobinIngelbrecht\PHPUnitCoverageTools\MinCoverage\MinCoverageResult::mapFromRulesAndMetrics(): Implicitly marking parameter $metricTotal as nullable is deprecated, the explicit nullable type must be used instead
```