### PR TITLE
PhpUnit 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": "^8.1",
     "ext-simplexml": "*",
     "ext-xmlreader": "*",
-    "phpunit/phpunit": "^10.3||^11.0||^12.0",
+    "phpunit/phpunit": "^10.3||^11.0||^12.0||^13.0",
     "symfony/console": "^5.4||^6.2||^7.0||^8.0"
   },
   "autoload": {

--- a/tests/Subscriber/Application/ApplicationFinishedSubscriberTest.php
+++ b/tests/Subscriber/Application/ApplicationFinishedSubscriberTest.php
@@ -493,6 +493,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParameters(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertEquals(
             new ApplicationFinishedSubscriber(
                 pathToCloverXml: 'tests/clover.xml',
@@ -514,6 +518,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParameters2(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertEquals(
             new ApplicationFinishedSubscriber(
                 pathToCloverXml: 'tests/clover.xml',
@@ -537,6 +545,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParametersFromFile(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertEquals(
             expected: new ApplicationFinishedSubscriber(
                 pathToCloverXml: 'tests/clover.xml',
@@ -558,6 +570,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParametersWhenInvalidMinCoverage(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertNull(
             actual: ApplicationFinishedSubscriber::fromConfigurationAndParameters(
                 configuration: (new Builder())->build([
@@ -571,6 +587,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParametersWhenCoverageTooHigh(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertNull(
             actual: ApplicationFinishedSubscriber::fromConfigurationAndParameters(
                 configuration: (new Builder())->build([
@@ -584,6 +604,10 @@ class ApplicationFinishedSubscriberTest extends TestCase
 
     public function testFromConfigurationAndParametersWhenRulesAreEmpty(): void
     {
+        $this->exitter
+            ->expects($this->never())
+            ->method('exit');
+
         $this->assertNull(
             ApplicationFinishedSubscriber::fromConfigurationAndParameters(
                 configuration: (new Builder())->build([


### PR DESCRIPTION
Supporting PhpUnit v13.

As of v12, tests caused warnings;

> No expectations were configured for the mock object for RobinIngelbrecht\PHPUnitCoverageTools\Exitter. 
> Consider refactoring your test code to use a test stub instead. 
> The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

Adding expects to "exitter" mock resolved this.

Tested with phpunit/phpstan for php version 8.2, 8.3, 8.4 and 8.5.